### PR TITLE
Display warning when outdated object version is in view

### DIFF
--- a/src/static/stylesheets/app.scss
+++ b/src/static/stylesheets/app.scss
@@ -105,10 +105,11 @@ header {
 .app-container {
   display: grid;
   grid-template-areas:
+  "nav warning"
   "nav header"
   "nav main";
   grid-template-columns: 10rem 1fr;
-  grid-template-rows: 3rem 1fr;
+  grid-template-rows: 2.5rem 3rem 1fr;
 
   .navigation-tabs {
     border: 0;
@@ -138,6 +139,13 @@ header {
 main {
   grid-area: main;
   padding: $elv-spacing-s;
+}
+
+.version-warning {
+  background-color: $elv-color-mediumred;
+  color: $elv-color-text-white;
+  grid-area: warning;
+  padding: $elv-spacing-xs $elv-spacing-s 0;
 }
 
 main,

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -25,6 +25,7 @@ class RootStore {
   @observable libraryId;
   @observable objectId;
   @observable versionHash;
+  @observable versionHashChanged = false;
   @observable writeToken;
 
   @observable initialized = false;
@@ -159,6 +160,11 @@ class RootStore {
   SetTimezone(zone) {
     Settings.defaultZoneName = zone;
     this.timezone = zone;
+  }
+
+  @action.bound
+  SetVersionHashChange = (value) => {
+    this.versionHashChanged = value;
   }
 
   FormatType(type) {


### PR DESCRIPTION
Problem: Customers who leave their browser open to the permissions manager end up overriding their team members' changes.

This changeset polls the latest version ONCE every 1 MINUTE and checks against current version hash to determine if the current version is out-of-date. If it is, a warning is displayed and the Save button is disabled.

A new grid area has been added for the warning notification, which could also show the notifications for Saving and any errors. Next step?

- Warning does not show while a save is in progress since the version hash is in the process of changing
- Warning shows on other clients where the page was "parked"
- Warning disappears on refresh
- Grid now has 3 areas instead of 2

<img width="1303" alt="Screen Shot 2022-02-03 at 1 02 04 PM" src="https://user-images.githubusercontent.com/91760982/152430483-90b32402-fd80-4b42-95d3-f49521273992.png">
