### PR TITLE
Trim id when saving oauth group permissions

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1544,7 +1544,7 @@ class RootStore {
               type: "group"
             };
           } else if(type === "oauthGroup") {
-            const groupInfo = this.allGroups[id];
+            const groupInfo = this.allGroups[id.trim()];
             if(!groupInfo) {
               this.LogError(`Unable to find OAuth group info for ${id}`);
             }


### PR DESCRIPTION
Trim id when getting group info for oauth groups.