### PR TITLE
Throw error on save if oauth group not found

### DIFF
--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1544,9 +1544,11 @@ class RootStore {
               type: "group"
             };
           } else if(type === "oauthGroup") {
-            const groupInfo = this.allGroups[id.trim()];
+            const groupInfo = this.allGroups[id];
             if(!groupInfo) {
-              this.LogError(`Unable to find OAuth group info for ${id}`);
+              const errorMessage = `Unable to find OAuth group info for ${id}`;
+              this.LogError(errorMessage);
+              throw Error(errorMessage);
             }
 
             itemPermission.subject = {

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -1544,7 +1544,7 @@ class RootStore {
               type: "group"
             };
           } else if(type === "oauthGroup") {
-            const groupInfo = this.allGroups[id];
+            const groupInfo = this.allGroups[id.trim()];
             if(!groupInfo) {
               const errorMessage = `Unable to find OAuth group info for ${id}`;
               this.LogError(errorMessage);


### PR DESCRIPTION
Throw error when attempting to save form and a group is not found within the list of groups from downloading the oauth sync hash part.
Note, title permissions are saved in a map like below
```
  titlePermissions: {
    iq__xxx: {
      00g1xxx: {},
      "TEST ": {} // untrimmed; note the extra space at the end
    }
  }
```
Another map is used to save groups form the downloaded part and structured like below
```
  allGroups: {
    00g1xxx: {},
    TEST: {} // trimmed
  }
```
 This works because of the address trim discrepancy. When saving, the code maps through the title permission profiles and checks each group id against `allGroups`, which fails because the keys are different. This doesn't affect unsynchronized groups.